### PR TITLE
ci: fetch LFS in the PyPI publish workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,6 +14,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        lfs: true
     
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
One-line fix: without `lfs: true`, the release-triggered wheel build packages LFS pointer files for the two `kirkland.json` data files instead of the real data (they were added to package-data in #23). Must land before the v0.2.0 release/tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)